### PR TITLE
ISSUE: 6-create-headless-browser

### DIFF
--- a/utils/scraper.js
+++ b/utils/scraper.js
@@ -11,7 +11,7 @@ class Scraper {
     // add headless: false if you want to see the webpages open
     try {
       this.browserInstance = await puppeteer.launch({
-        headless: false,
+        headless: "new",
         args: ["--disable-setuid-sandbox"],
         ignoreHTTPSErrors: true,
       });


### PR DESCRIPTION
keep the web browser from creating a graphical user interface when a new browser instance is created